### PR TITLE
add support for datefmt in FakeLogger

### DIFF
--- a/fixtures/_fixtures/logger.py
+++ b/fixtures/_fixtures/logger.py
@@ -65,13 +65,16 @@ class LogHandler(Fixture):
 class FakeLogger(Fixture):
     """Replace a logger and capture its output."""
 
-    def __init__(self, name="", level=INFO, format=None, nuke_handlers=True):
+    def __init__(self, name="", level=INFO, format=None,
+                 datefmt=None, nuke_handlers=True):
         """Create a FakeLogger fixture.
 
         :param name: The name of the logger to replace. Defaults to "".
         :param level: The log level to set, defaults to INFO.
         :param format: Logging format to use. Defaults to capturing supplied
             messages verbatim.
+        :param datefmt: Logging date format to use.
+            Mirrors the datefmt used in python loggging.
         :param nuke_handlers: If True remove all existing handles (prevents
             existing messages going to e.g. stdout). Defaults to True.
 
@@ -86,6 +89,7 @@ class FakeLogger(Fixture):
         self._name = name
         self._level = level
         self._format = format
+        self._datefmt = datefmt
         self._nuke_handlers = nuke_handlers
 
     def setUp(self):
@@ -95,7 +99,7 @@ class FakeLogger(Fixture):
         self._output = output
         handler = StreamHandler(output)
         if self._format:
-            handler.setFormatter(Formatter(self._format))
+            handler.setFormatter(Formatter(self._format, self._datefmt))
         self.useFixture(
             LogHandler(handler, name=self._name, level=self._level,
                        nuke_handlers=self._nuke_handlers))

--- a/fixtures/tests/_fixtures/test_logger.py
+++ b/fixtures/tests/_fixtures/test_logger.py
@@ -14,6 +14,7 @@
 # limitations under that license.
 
 import logging
+import time
 
 from testtools import TestCase
 from testtools.compat import StringIO
@@ -80,6 +81,15 @@ class FakeLoggerTest(TestCase, TestWithFixtures):
         self.useFixture(fixture)
         logging.info("message")
         self.assertEqual("test_logger\n", fixture.output)
+
+    def test_custom_datefmt(self):
+        fixture = FakeLogger(format="%(asctime)s %(module)s",
+                             datefmt="%Y")
+        self.useFixture(fixture)
+        logging.info("message")
+        self.assertEqual(
+            time.strftime("%Y test_logger\n", time.localtime()),
+            fixture.output)
 
     def test_logging_output_included_in_details(self):
         fixture = FakeLogger()


### PR DESCRIPTION
The logging fixture is extremely useful to be used a temp buffer for
collecting log messages into a buffer, and only decide if we're going
to emit them after some event in the future (like the failure or
success of some future criteria). However, in it's current form we are
not given access to the datefmt variable of the underlying Formatter,
which means we always end up with the default python time string for
%(asctime), which looks incorrectly localized many places.

This merely adds the ability to pass the datefmt param through to the
Formatter.

Signed-off-by: Sean Dague sean@dague.net
