### PR TITLE
Add a warnings module capture fixure

### DIFF
--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -69,6 +69,7 @@ __all__ = [
     'TestWithFixtures',
     'Timeout',
     'TimeoutException',
+    'WarningsCapture',
     '__version__',
     'version',
     ]
@@ -99,6 +100,7 @@ from fixtures._fixtures import (
     TempHomeDir,
     Timeout,
     TimeoutException,
+    WarningsCapture,
     )
 from fixtures.testcase import TestWithFixtures
 

--- a/fixtures/_fixtures/__init__.py
+++ b/fixtures/_fixtures/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     'TempHomeDir',
     'Timeout',
     'TimeoutException',
+    'WarningsCapture',
     ]
 
 
@@ -71,4 +72,7 @@ from fixtures._fixtures.temphomedir import (
 from fixtures._fixtures.timeout import (
     Timeout,
     TimeoutException,
+    )
+from fixtures._fixtures.warnings import (
+    WarningsCapture,
     )

--- a/fixtures/_fixtures/warnings.py
+++ b/fixtures/_fixtures/warnings.py
@@ -1,0 +1,47 @@
+#  fixtures: Fixtures with cleanups for testing and convenience.
+#
+# Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+# license at the users choice. A copy of both licenses are available in the
+# project source as Apache-2.0 and BSD. You may not use this file except in
+# compliance with one of these two licences.
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# license you chose for the specific language governing permissions and
+# limitations under that license.
+
+from __future__ import absolute_import
+
+__all__ = [
+    'WarningsCapture',
+    ]
+
+import warnings
+
+import fixtures
+
+
+class WarningsCapture(fixtures.Fixture):
+    """A fixture context manager that copies and restores the warnings filter
+       upon exiting the fixture.
+    """
+
+    def __init__(self):
+        self._captures = []
+
+    def clear(self):
+        self._captures = []
+
+    @property
+    def captures(self):
+        return self._captures
+
+    def _showwarning(self, *args, **kwargs):
+        msg = warnings.WarningMessage(*args, **kwargs)
+        self._captures.append(msg)
+
+    def setUp(self):
+        super(WarningsCapture, self).setUp()
+        patch = fixtures.MonkeyPatch("warnings.showwarning", self._showwarning)
+        self.useFixture(patch)

--- a/fixtures/tests/_fixtures/test_warnings.py
+++ b/fixtures/tests/_fixtures/test_warnings.py
@@ -1,0 +1,44 @@
+#  fixtures: Fixtures with cleanups for testing and convenience.
+#
+# Copyright (C) 2011, Martin Pool <mbp@sourcefrog.net>
+# 
+# Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+# license at the users choice. A copy of both licenses are available in the
+# project source as Apache-2.0 and BSD. You may not use this file except in
+# compliance with one of these two licences.
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# license you chose for the specific language governing permissions and
+# limitations under that license.
+
+import warnings
+
+import testtools
+
+import fixtures
+
+
+class TestWarnings(testtools.TestCase, fixtures.TestWithFixtures):
+    def test_capture_message(self):
+        w = self.useFixture(fixtures.WarningsCapture())
+
+        warnings.warn("hi", DeprecationWarning, stacklevel=2)
+        self.assertEqual(1, len(w.captures))
+        self.assertEqual("hi", str(w.captures[0].message))
+
+    def test_capture_category(self):
+        w = self.useFixture(fixtures.WarningsCapture())
+        categories = [
+            DeprecationWarning, Warning, UserWarning,
+            SyntaxWarning, RuntimeWarning,
+            UnicodeWarning, FutureWarning,
+        ]
+        for category in categories:
+            warnings.warn("test", category, stacklevel=2)
+
+        self.assertEqual(len(categories), len(w.captures))
+        for i, category in enumerate(categories):
+            c = w.captures[i]
+            self.assertEqual(category, c.category)

--- a/fixtures/tests/_fixtures/test_warnings.py
+++ b/fixtures/tests/_fixtures/test_warnings.py
@@ -1,7 +1,5 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
-# Copyright (C) 2011, Martin Pool <mbp@sourcefrog.net>
-# 
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in


### PR DESCRIPTION
Capturing the warnings module output (which is typically used
for deprecating code or functions or modules) is quite useful and
is a frequent operation that can be required to perform. So provide
a fixture that is similar (but not the same) as the warnings
``catch_warnings`` context manager that can be used to gather all
warnings emitted and allows people to later analyze them to ensure
they are as they expect.