### PR TITLE
add tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27
+minversion = 1.6
+skipsdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install -U {opts} {packages}
+setenv = VIRTUAL_ENV={envdir}
+whitelist_externals = make
+deps = -r{toxinidir}/requirements.txt
+commands = make check


### PR DESCRIPTION
Provide tox configuration to make it easy to run tests locally against
different python environments without have to install dependencies
into the system. The default env is left at py27 only for
compatibility, however tox -e py33 and tox -e py34 will work fine with
this in place.