### PR TITLE
Add a warnings module capture fixure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,8 @@ fixtures release notes
 NEXT
 ~~~~
 
+* Add warnings module fixture for capturing warnings. (Joshua Harlow)
+
 1.1.0
 ~~~~~
 

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -66,6 +66,7 @@ __all__ = [
     'TestWithFixtures',
     'Timeout',
     'TimeoutException',
+    'WarningsCapture',
     '__version__',
     'version',
     ]
@@ -96,6 +97,7 @@ from fixtures._fixtures import (
     TempHomeDir,
     Timeout,
     TimeoutException,
+    WarningsCapture,
     )
 from fixtures.testcase import TestWithFixtures
 

--- a/fixtures/_fixtures/__init__.py
+++ b/fixtures/_fixtures/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     'TempHomeDir',
     'Timeout',
     'TimeoutException',
+    'WarningsCapture',
     ]
 
 
@@ -71,4 +72,7 @@ from fixtures._fixtures.temphomedir import (
 from fixtures._fixtures.timeout import (
     Timeout,
     TimeoutException,
+    )
+from fixtures._fixtures.warnings import (
+    WarningsCapture,
     )

--- a/fixtures/_fixtures/warnings.py
+++ b/fixtures/_fixtures/warnings.py
@@ -1,0 +1,41 @@
+#  fixtures: Fixtures with cleanups for testing and convenience.
+#
+# Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+# license at the users choice. A copy of both licenses are available in the
+# project source as Apache-2.0 and BSD. You may not use this file except in
+# compliance with one of these two licences.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# license you chose for the specific language governing permissions and
+# limitations under that license.
+
+from __future__ import absolute_import
+
+__all__ = [
+    'WarningsCapture',
+]
+
+import warnings
+
+import fixtures
+
+
+class WarningsCapture(fixtures.Fixture):
+    """Capture warnings.
+
+    While ``WarningsCapture`` is active, warnings will be captured by
+    the fixture (so that they can be later analyzed).
+
+    :attribute captures: A list of warning capture ``WarningMessage`` objects.
+    """
+
+    def _showwarning(self, *args, **kwargs):
+        self.captures.append(warnings.WarningMessage(*args, **kwargs))
+
+    def setUp(self):
+        super(WarningsCapture, self).setUp()
+        patch = fixtures.MonkeyPatch("warnings.showwarning", self._showwarning)
+        self.useFixture(patch)
+        self.captures = []

--- a/fixtures/tests/_fixtures/test_warnings.py
+++ b/fixtures/tests/_fixtures/test_warnings.py
@@ -1,0 +1,49 @@
+#  fixtures: Fixtures with cleanups for testing and convenience.
+#
+# Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+# license at the users choice. A copy of both licenses are available in the
+# project source as Apache-2.0 and BSD. You may not use this file except in
+# compliance with one of these two licences.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# license you chose for the specific language governing permissions and
+# limitations under that license.
+
+import warnings
+
+import testtools
+
+import fixtures
+
+
+class TestWarnings(testtools.TestCase, fixtures.TestWithFixtures):
+
+    def test_capture_reuse(self):
+        w = fixtures.WarningsCapture()
+        with w:
+            warnings.warn("test", DeprecationWarning)
+            self.assertEqual(1, len(w.captures))
+        with w:
+            self.assertEqual([], w.captures)
+
+    def test_capture_message(self):
+        w = self.useFixture(fixtures.WarningsCapture())
+        warnings.warn("hi", DeprecationWarning)
+        self.assertEqual(1, len(w.captures))
+        self.assertEqual("hi", str(w.captures[0].message))
+
+    def test_capture_category(self):
+        w = self.useFixture(fixtures.WarningsCapture())
+        categories = [
+            DeprecationWarning, Warning, UserWarning,
+            SyntaxWarning, RuntimeWarning,
+            UnicodeWarning, FutureWarning,
+        ]
+        for category in categories:
+            warnings.warn("test", category)
+        self.assertEqual(len(categories), len(w.captures))
+        for i, category in enumerate(categories):
+            c = w.captures[i]
+            self.assertEqual(category, c.category)


### PR DESCRIPTION
Capturing the warnings module output (which is typically used
for deprecating code or functions or modules) is quite useful and
is a frequent operation that can be required to perform. So provide
a fixture that is similar (but not the same) as the warnings
``catch_warnings`` context manager that can be used to gather all
warnings emitted and allows people to later analyze them to ensure
they are as they expect.