### PR TITLE
Fix Bug #1451989 -- Code is now PEP 396 compliant

### DIFF
--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -38,7 +38,8 @@ Most users will want to look at TestWithFixtures and Fixture, to start with.
 # Otherwise it is major.minor.micro~$(revno).
 from pbr.version import VersionInfo
 _version = VersionInfo('fixtures')
-__version__ = _version.semantic_version().version_tuple()
+__version_info__ = _version.semantic_version().version_tuple()
+__version__ = _version.release_string()
 version = _version.release_string()
 
 


### PR DESCRIPTION
`__version__` now returns a version string instead of a tuple per [PEP 396](https://www.python.org/dev/peps/pep-0396/). Added `__version_info__ ` which returns a version tuple. Fixes [Bug #1451989](https://bugs.launchpad.net/python-fixtures/+bug/1451989).