### PR TITLE
Update homepage link

### DIFF
--- a/README
+++ b/README
@@ -31,7 +31,7 @@ Dependencies
 * pbr
   Used for version and release management of fixtures.
 
-* testtools <https://launchpad.net/testtools> 0.9.22 or newer.
+* testtools <https://github.com/testing-cabal/testtools> 0.9.22 or newer.
   testtools provides helpful glue functions for the details API used to report
   information about a fixture (whether its used in a testing or production
   environment).

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ description-file =
     README
 author = Robert Collins
 author-email = robertc@robertcollins.net
-home-page = https://launchpad.net/python-fixtures
+home-page = https://github.com/testing-cabal/fixtures
 classifier =
     Development Status :: 6 - Mature
     Intended Audience :: Developers


### PR DESCRIPTION
Update the homepage link to point to the github repository instead of
the outdated launchpad project. Fix a similar reference to the testtools
home page in the README.