### PR TITLE
FakeLogger: Mis-formatted log messages will raise Exception

### DIFF
--- a/fixtures/_fixtures/logger.py
+++ b/fixtures/_fixtures/logger.py
@@ -14,6 +14,7 @@
 # limitations under that license.
 
 from logging import StreamHandler, getLogger, INFO, Formatter
+import sys
 
 from testtools.compat import _u
 
@@ -61,6 +62,13 @@ class LogHandler(Fixture):
             self.addCleanup(logger.removeHandler, self.handler)
 
 
+class StreamHandlerRaiseException(StreamHandler):
+    """Handler class that will raise an exception on formatting errors."""
+    def handleError(self, record):
+        ei = sys.exc_info()
+        raise ei[0], ei[1], ei[2]
+
+
 class FakeLogger(Fixture):
     """Replace a logger and capture its output."""
 
@@ -98,7 +106,7 @@ class FakeLogger(Fixture):
         name = _u("pythonlogging:'%s'") % self._name
         output = self.useFixture(StringStream(name)).stream
         self._output = output
-        handler = StreamHandler(output)
+        handler = StreamHandlerRaiseException(output)
         if self._format:
             formatter = (self._formatter or Formatter)
             handler.setFormatter(formatter(self._format, self._datefmt))

--- a/fixtures/tests/_fixtures/test_logger.py
+++ b/fixtures/tests/_fixtures/test_logger.py
@@ -140,6 +140,13 @@ class FakeLoggerTest(TestCase, TestWithFixtures):
         except:
             pass
 
+    def test_exceptionraised(self):
+        fixture = self.useFixture(FakeLogger())
+        self.assertRaises(TypeError,
+                          logging.info,
+                          "some message",
+                          "wrongarg")
+
 
 class LogHandlerTest(TestCase, TestWithFixtures):
 


### PR DESCRIPTION
(from https://github.com/testing-cabal/fixtures/pull/13 - rebased to test with travis) 


When using the FakeLogger, have mis-formatted logging messages raise an
exception.

Normally when using the logging module, mis-formatted logging messages
will not raise an exception. Instead the exception will be printed but
not raised.

Change this behavior so that mis-formatted log messages can be caught
during unit-testing.

Closes-Bug: #1503049
Change-Id: I8d3e94d131289300ae020eb1d63306489e986335