### PR TITLE
Spelling and lint fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,7 +35,7 @@ NEXT
 * Fixture.setUp should no longer be overridden in subclasses. Instead
   override _setUp. This permits the Fixture base class to detect failures
   during _setUp and trigger any registered cleanups, attach any details
-  to the failure exception and propogate that to callers. Overriding of
+  to the failure exception and propagate that to callers. Overriding of
   setUp is still supported: this adds a new interface for simpler
   implementation of the contract of a fixture.
   (Robert Collins, #1456361, #1456353)

--- a/README
+++ b/README
@@ -56,7 +56,7 @@ Why Fixtures
 
 Standard Python unittest.py provides no obvious method for making and reusing
 state needed in a test case other than by adding a method on the test class.
-This scales poorly - complex helper functions propogating up a test class
+This scales poorly - complex helper functions propagating up a test class
 hierarchy is a regular pattern when this is done. Mocking while a great tool
 doesn't itself prevent this (and helpers to mock complex things can accumulate
 in the same way if placed on the test class).
@@ -230,7 +230,7 @@ The examples above used ``_setUp`` rather than ``setUp`` because the base
 class implementation of ``setUp`` acts to reduce the chance of leaking
 external resources if an error is raised from ``_setUp``. Specifically,
 ``setUp`` contains a try:/except: block which catches all exceptions, captures
-any registered detail objects, and calls ``self.cleanUp`` before propogating
+any registered detail objects, and calls ``self.cleanUp`` before propagating
 the error. As long as you take care to register any cleanups before calling
 the code that may fail, this will cause them to be cleaned up. The captured
 detail objects are provided to the args of the raised exception.

--- a/fixtures/callmany.py
+++ b/fixtures/callmany.py
@@ -97,4 +97,4 @@ class CallMany(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self()
-        return False  # propogate exceptions from the with body.
+        return False  # Propagate exceptions from the with body.

--- a/fixtures/callmany.py
+++ b/fixtures/callmany.py
@@ -67,7 +67,8 @@ class CallMany(object):
             re-raised after all the functions have run.  If multiple exceptions
             are raised, they are all wrapped into a MultipleExceptions object,
             and that is raised.
-            Thus, to cach a specific exception from a function run by __call__,
+
+            Thus, to catch a specific exception from a function run by __call__,
             you need to catch both the exception and MultipleExceptions, and
             then check within a MultipleExceptions instance for an occurance of
             the type you wish to catch.
@@ -96,5 +97,4 @@ class CallMany(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self()
-        return False # propogate exceptions from the with body.
-
+        return False  # propogate exceptions from the with body.

--- a/fixtures/fixture.py
+++ b/fixtures/fixture.py
@@ -156,7 +156,7 @@ class Fixture(object):
             self._cleanups()
         finally:
             self._remove_state()
-        return False  # propogate exceptions from the with body.
+        return False  # propagate exceptions from the with body.
 
     def getDetails(self):
         """Get the current details registered with the fixture.

--- a/fixtures/fixture.py
+++ b/fixtures/fixture.py
@@ -27,7 +27,6 @@ import sys
 import six
 from testtools.compat import (
     advance_iterator,
-    reraise,
     )
 from testtools.helpers import try_import
 
@@ -115,7 +114,7 @@ class Fixture(object):
             if a single exception is raised, it is reraised after all the
             cleanUps have run. If multiple exceptions are raised, they are
             all wrapped into a MultipleExceptions object, and that is reraised.
-            Thus, to cach a specific exception from cleanUp, you need to catch
+            Thus, to catch a specific exception from cleanUp, you need to catch
             both the exception and MultipleExceptions, and then check within
             a MultipleExceptions instance for the type you're catching.
         :return: A list of the exc_info() for each exception that occured if
@@ -157,7 +156,7 @@ class Fixture(object):
             self._cleanups()
         finally:
             self._remove_state()
-        return False # propogate exceptions from the with body.
+        return False  # propogate exceptions from the with body.
 
     def getDetails(self):
         """Get the current details registered with the fixture.
@@ -206,7 +205,7 @@ class Fixture(object):
             errors = [err] + self.cleanUp(raise_first=False)
             try:
                 raise SetupError(details)
-            except SetupError as e:
+            except SetupError:
                 errors.append(sys.exc_info())
             if issubclass(err[0], Exception):
                 raise MultipleExceptions(*errors)
@@ -381,12 +380,12 @@ class MethodFixture(Fixture):
         if setup is None:
             setup = getattr(obj, 'setUp', None)
             if setup is None:
-                setup = lambda:None
+                setup = lambda: None
         self._setup = setup
         if cleanup is None:
             cleanup = getattr(obj, 'tearDown', None)
             if cleanup is None:
-                cleanup = lambda:None
+                cleanup = lambda: None
         self._cleanup = cleanup
         if reset is None:
             reset = getattr(obj, 'reset', None)

--- a/fixtures/tests/test_callmany.py
+++ b/fixtures/tests/test_callmany.py
@@ -45,7 +45,7 @@ class TestCallMany(testtools.TestCase):
         self.assertEqual(('woo',), value.args)
         self.assertIsInstance(tb, types.TracebackType)
 
-    def test_exit_propogates_exceptions(self):
+    def test_exit_propagates_exceptions(self):
         call = CallMany()
         call.__enter__()
         self.assertEqual(False, call.__exit__(None, None, None))

--- a/fixtures/tests/test_fixture.py
+++ b/fixtures/tests/test_fixture.py
@@ -84,7 +84,7 @@ class TestFixture(testtools.TestCase):
         self.assertEqual(('woo',), value.args)
         self.assertIsInstance(tb, types.TracebackType)
 
-    def test_exit_propogates_exceptions(self):
+    def test_exit_propagates_exceptions(self):
         fixture = fixtures.Fixture()
         fixture.__enter__()
         self.assertEqual(False, fixture.__exit__(None, None, None))
@@ -259,7 +259,7 @@ class TestFixture(testtools.TestCase):
 
     def test_setup_failures_with_base_exception(self):
         # when _setUp fails with a BaseException (or subclass thereof) that
-        # exception is propogated as is, but we still call cleanups etc.
+        # exception is propagated as is, but we still call cleanups etc.
         class MyBase(BaseException):pass
         log = []
         class Subclass(fixtures.Fixture):


### PR DESCRIPTION
Mostly just "cach" -> "catch". Also fixes some whitespace & unused imports while I was there.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/17)
<!-- Reviewable:end -->
