### PR TITLE
Python 3 MonkeyPatch staticmethod

### DIFF
--- a/fixtures/tests/_fixtures/test_monkeypatch.py
+++ b/fixtures/tests/_fixtures/test_monkeypatch.py
@@ -78,6 +78,8 @@ class TestMonkeyPatch(testtools.TestCase, TestWithFixtures):
             'fixtures.tests._fixtures.test_monkeypatch.C.foo',
             bar)
         with fixture:
-            pass
+            C.foo()
+            C().foo()
         self.assertEqual(oldfoo, C.foo)
+        self.assertEqual(oldfoo, C().foo)
 


### PR DESCRIPTION
In Python setattr(Class, name, func) automatically converts a function
into an instancemethod. To keep type(Class.func) as function,
staticmethod(func) must be applied explicitly. This was previously fixed
for Python 2 but the issue exists for 3 as well.

The test for this case was updated to correctly check it. The method
does not become bound until the class it is defined on is instantiated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/23)
<!-- Reviewable:end -->
