### PR TITLE
Fix print in README

### DIFF
--- a/README
+++ b/README
@@ -151,7 +151,7 @@ You can also combine existing fixtures using ``CompoundFixture``::
   >>> noddy_with_log = fixtures.CompoundFixture([NoddyFixture(),
   ...                                            WithLog()])
   >>> with noddy_with_log as x:
-  ...     print x.fixtures[0].frobnozzle
+  ...     print (x.fixtures[0].frobnozzle)
   42
 
 The Fixture API


### PR DESCRIPTION
Python 3 tests were failing on the improper usage of print in the README
examples. Print must be used as a method in Python 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/24)
<!-- Reviewable:end -->
