### PR TITLE
Ignore .tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ AUTHORS
 ChangeLog
 .eggs
 build
+.tox


### PR DESCRIPTION
.tox is created when running tox for the tests. Ignore it so
it's not accidentally checked in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/28)
<!-- Reviewable:end -->
