### PR TITLE
Add support for attaching logs on error.

### DIFF
--- a/fixtures/_fixtures/logger.py
+++ b/fixtures/_fixtures/logger.py
@@ -73,7 +73,8 @@ class FakeLogger(Fixture):
     """Replace a logger and capture its output."""
 
     def __init__(self, name="", level=INFO, format=None,
-                 datefmt=None, nuke_handlers=True, formatter=None):
+                 datefmt=None, nuke_handlers=True, formatter=None,
+                 only_on_error=False):
         """Create a FakeLogger fixture.
 
         :param name: The name of the logger to replace. Defaults to "".
@@ -86,6 +87,9 @@ class FakeLogger(Fixture):
             existing messages going to e.g. stdout). Defaults to True.
         :param formatter: a custom log formatter class. Use this if you want
             to use a log Formatter other than the default one in python.
+        :param only_on_error: Only attach the captured output to the TestResult
+            if the test fails. This can be important for some test suites where
+            the full debug logging needed is enormous.
 
         Example:
 
@@ -101,10 +105,12 @@ class FakeLogger(Fixture):
         self._datefmt = datefmt
         self._nuke_handlers = nuke_handlers
         self._formatter = formatter
+        self._only_on_error = only_on_error
 
     def _setUp(self):
         name = _u("pythonlogging:'%s'") % self._name
-        output = self.useFixture(StringStream(name)).stream
+        output = self.useFixture(
+            StringStream(name, only_on_error=self._only_on_error)).stream
         self._output = output
         handler = StreamHandlerRaiseException(output)
         if self._format:

--- a/fixtures/_fixtures/streams.py
+++ b/fixtures/_fixtures/streams.py
@@ -32,17 +32,25 @@ class Stream(Fixture):
     :attr stream: The file-like object.
     """
 
-    def __init__(self, detail_name, stream_factory):
+    def __init__(self, detail_name, stream_factory, only_on_error=False):
         """Create a ByteStream.
 
         :param detail_name: Use this as the name of the stream.
         :param stream_factory: Called to construct a pair of streams:
             (write_stream, content_stream).
+        :param only_on_error: Only attach the stream output if an error occurs.
         """
         self._detail_name = detail_name
         self._stream_factory = stream_factory
+        self._only_on_error = only_on_error
 
     def _setUp(self):
+        if self._only_on_error:
+            self.addOnException(self._add_stream_detail)
+        else:
+            self._add_stream_detail()
+
+    def _add_stream_detail(self):
         write_stream, read_stream = self._stream_factory()
         self.stream = write_stream
         self.addDetail(self._detail_name,


### PR DESCRIPTION
Sometimes, code being tested can produce a large amount of output which
is needed to debug issues. Adding that output to successful tests can
lead to blowing out size maximums for a full test suite run, even if
only one test fails, because of adding the log streaming output to every
test all the time.

To empower users to only collect that output on failures, expose a flag
on the constructor which causes addOnException to be used instead of the
normal addDetail. The default stays at off so existing users should not
see a behavior change.