### PR TITLE
Add python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
   - pypy3
   - "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-  - pypy3
+  - "pypy3.3-5.2-alpha1"
   - "nightly"
 
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,py36,pypy,pypy3
+envlist = py26,py27,py33,py34,py35,py36,pypy,pypy3
 minversion = 1.6
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,py35,pypy,pypy3
+envlist = py26,py27,py32,py33,py34,py35,py36,pypy,pypy3
 minversion = 1.6
 skipsdist = True
 


### PR DESCRIPTION
Add 3.6 to the list of Python versions that Travis/tox will exercise. Also, switch the pypy3 target to version 3.3 (since pkg_resources is not supported anymore on 3.2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/36)
<!-- Reviewable:end -->
