### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-  - "pypy3.3-5.2-alpha1"
+  - "pypy3"
   - "nightly"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README
+++ b/README
@@ -25,7 +25,7 @@ compatible test cases easy and straight forward.
 Dependencies
 ============
 
-* Python 2.7 or 3.3+
+* Python 2.7 or 3.4+
   This is the base language fixtures is written in and for.
 
 * pbr

--- a/README
+++ b/README
@@ -3,12 +3,12 @@ fixtures: Fixtures with cleanups for testing and convenience.
 *************************************************************
 
   Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-  
+
   Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
   license at the users choice. A copy of both licenses are available in the
   project source as Apache-2.0 and BSD. You may not use this file except in
   compliance with one of these two licences.
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -25,7 +25,7 @@ compatible test cases easy and straight forward.
 Dependencies
 ============
 
-* Python 2.6+, or 3.3+
+* Python 2.7 or 3.3+
   This is the base language fixtures is written in and for.
 
 * pbr
@@ -39,8 +39,6 @@ Dependencies
 For use in a unit test suite using the included glue, one of:
 
 * Python 2.7+
-
-* unittest2
 
 * bzrlib.tests
 
@@ -488,7 +486,7 @@ seconds.
 There are two possibilities, controlled by the 'gentle' argument: when gentle,
 an exception will be raised and the test (or other covered code) will fail.
 When not gentle, the entire process will be terminated, which is less clean,
-but more likely to break hangs where no Python code is running.  
+but more likely to break hangs where no Python code is running.
 
 *Caution:* Only one timeout can be active at any time across all threads in a
 single process.  Using more than one has undefined results.  (This could be

--- a/fixtures/_fixtures/monkeypatch.py
+++ b/fixtures/_fixtures/monkeypatch.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -18,7 +18,6 @@ __all__ = [
     ]
 
 import functools
-import sys
 import types
 
 from fixtures import Fixture
@@ -32,12 +31,12 @@ if getattr(types, 'ClassType', None):
 
 def _coerce_values(obj, name, new_value, sentinel):
     """Return an adapted (new_value, old_value) for patching obj.name.
-    
+
     setattr transforms a function into an instancemethod when set on a class.
     This checks if the attribute to be replaced is a callable descriptor -
     staticmethod, classmethod, or types.FunctionType - and wraps new_value if
     necessary.
-    
+
     This also checks getattr(obj, name) and wraps it if necessary
     since the staticmethod wrapper isn't preserved.
 
@@ -130,7 +129,7 @@ class MonkeyPatch(Fixture):
         Fixture.__init__(self)
         self.name = name
         self.new_value = new_value
-    
+
     def _setUp(self):
         location, attribute = self.name.rsplit('.', 1)
         # Import, swallowing all errors as any element of location may be

--- a/fixtures/tests/__init__.py
+++ b/fixtures/tests/__init__.py
@@ -16,8 +16,6 @@
 import doctest
 import unittest
 
-import fixtures.tests._fixtures
-
 
 def test_suite():
     standard_tests = unittest.TestSuite()

--- a/fixtures/tests/__init__.py
+++ b/fixtures/tests/__init__.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -14,7 +14,6 @@
 # limitations under that license.
 
 import doctest
-import sys
 import unittest
 
 import fixtures.tests._fixtures
@@ -35,13 +34,8 @@ def load_tests(loader, standard_tests, pattern):
     prefix = "fixtures.tests.test_"
     test_mod_names = [prefix + test_module for test_module in test_modules]
     standard_tests.addTests(loader.loadTestsFromNames(test_mod_names))
-    if sys.version_info >= (2, 7):
-        # 2.7 calls load_tests for us
-        standard_tests.addTests(loader.loadTestsFromName('fixtures.tests._fixtures'))
-    else:
-        # We need to call it ourselves.
-        standard_tests.addTests(fixtures.tests._fixtures.load_tests(
-            loader, loader.loadTestsFromName('fixtures.tests._fixtures'), pattern))
+    standard_tests.addTests(
+        loader.loadTestsFromName('fixtures.tests._fixtures'))
     doctest.set_unittest_reportflags(doctest.REPORT_ONLY_FIRST_FAILURE)
     standard_tests.addTest(doctest.DocFileSuite("../../README"))
     return standard_tests

--- a/fixtures/tests/_fixtures/test_mockpatch.py
+++ b/fixtures/tests/_fixtures/test_mockpatch.py
@@ -13,7 +13,6 @@
 #    under the License.
 
 
-import extras
 import mock # Yes, we only test the rolling backport
 import testtools
 

--- a/fixtures/tests/_fixtures/test_popen.py
+++ b/fixtures/tests/_fixtures/test_popen.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, 2011, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -62,7 +62,7 @@ class TestFakePopen(testtools.TestCase, TestWithFixtures):
             self.assertEqual(all_args, proc_args)
             return {}
         fixture = self.useFixture(FakePopen(get_info))
-        proc = fixture(**all_args)
+        fixture(**all_args)
 
     def test_custom_returncode(self):
         def get_info(proc_args):
@@ -73,7 +73,7 @@ class TestFakePopen(testtools.TestCase, TestWithFixtures):
         self.assertEqual(1, proc.returncode)
 
     def test_with_popen_custom(self):
-        fixture = self.useFixture(FakePopen())
+        self.useFixture(FakePopen())
         with subprocess.Popen(['ls -lh']) as proc:
             self.assertEqual(None, proc.returncode)
             self.assertEqual(['ls -lh'], proc.args)

--- a/fixtures/tests/test_fixture.py
+++ b/fixtures/tests/test_fixture.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -268,7 +268,7 @@ class TestFixture(testtools.TestCase):
                 self.addCleanup(log.append, 'cleaned')
                 raise MyBase('fred')
         f = Subclass()
-        e = self.assertRaises(MyBase, f.setUp)
+        self.assertRaises(MyBase, f.setUp)
         self.assertRaises(TypeError, f.cleanUp)
         self.assertEqual(['cleaned'], log)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifier =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy,pypy3
+envlist = py27,py34,py35,py36,pypy,pypy3
 minversion = 1.6
 skipsdist = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,pypy,pypy3
+envlist = py27,py33,py34,py35,py36,pypy,pypy3
 minversion = 1.6
 skipsdist = True
 


### PR DESCRIPTION
The [CI fails with latest master for Python 2.6 builds](https://travis-ci.org/hugovk/fixtures/builds/287401621) which also causes PRs to fail (eg. https://github.com/testing-cabal/fixtures/pull/39).

The easiest way to fix it is to just drop support for Python 2.6. I see testtools already dropped it in
https://github.com/testing-cabal/testtools/pull/198.

## Other reasons for dropping 2.6

* Unsupported since [2013-10-29](https://en.wikipedia.org/wiki/CPython#Version_history)
* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* http://www.python3statement.org
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)
* Not much PyPI traffic (June 2016) https://github.com/pypa/pip/issues/3796

(Python 3.3 also became EOL last month.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/40)
<!-- Reviewable:end -->
