### PR TITLE
Add possibility to reset the FakeLogger

### DIFF
--- a/fixtures/_fixtures/logger.py
+++ b/fixtures/_fixtures/logger.py
@@ -119,5 +119,8 @@ class FakeLogger(Fixture):
         self._output.seek(0)
         return self._output.read()
 
+    def reset_output(self):
+        self._output.truncate(0)
+
 
 LoggerFixture = FakeLogger

--- a/fixtures/tests/_fixtures/test_logger.py
+++ b/fixtures/tests/_fixtures/test_logger.py
@@ -146,6 +146,15 @@ class FakeLoggerTest(TestCase, TestWithFixtures):
             with testtools.ExpectedException(TypeError):
                 logging.info("Some message", "wrongarg")
 
+    def test_output_can_be_reset(self):
+        fixture = FakeLogger()
+        with fixture:
+            logging.info("message")
+
+        fixture.reset_output()
+
+        self.assertEqual("", fixture.output)
+
 
 class LogHandlerTest(TestCase, TestWithFixtures):
 


### PR DESCRIPTION
A long test case might emit extensive logs that subunit does not
really handle well [1]. So it is useful to reset the logs stored
in the fixture at certain points in the test execution[2].

To be able to do that this patch adds reset_output() call to the
FakeLogger.

[1] https://bugs.launchpad.net/nova/+bug/1813147
[2] https://review.opendev.org/#/c/656844

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/42)
<!-- Reviewable:end -->
