### PR TITLE
Drop Python < 3.6 support, add 3.7 - 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
-sudo: false
+---
 language: python
 
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
-  - "pypy"
+  - "3.7"
+  - "3.8"
+  - "3.9"
   - "pypy3"
   - "nightly"
 
 install:
- - pip install -U pip
- - pip install -U wheel setuptools pbr
- - pip install -U .[docs,test]
- - pip list
- - python --version
+  - pip install -U pip
+  - pip install -U wheel setuptools pbr
+  - pip install -U .[docs,test]
+  - pip list
+  - python --version
 
 script:
- - make check
- - rst2html.py README README.html
+  - make check
+  - rst2html.py README README.html

--- a/NEWS
+++ b/NEWS
@@ -2,9 +2,11 @@
 fixtures release notes
 ----------------------
 
-
 NEXT
 ~~~~
+
+* Dropped support for Python 2.7, Python 3.4 and Python 3.5 (EOL)
+* Added support for Python 3.7, Python 3.8, and Python 3.9
 
 3.0.0
 ~~~~~

--- a/README
+++ b/README
@@ -358,7 +358,7 @@ FakePopen
 Pretend to run an external command rather than needing it to be present to run
 tests.
 
-  >>> from testtools.compat import BytesIO
+  >>> from io import BytesIO
   >>> fixture = fixtures.FakePopen(lambda _:{'stdout': BytesIO('foobar')})
 
 MockPatchObject

--- a/README
+++ b/README
@@ -25,7 +25,7 @@ compatible test cases easy and straight forward.
 Dependencies
 ============
 
-* Python 2.7 or 3.4+
+* Python 3.6+
   This is the base language fixtures is written in and for.
 
 * pbr
@@ -37,8 +37,6 @@ Dependencies
   environment).
 
 For use in a unit test suite using the included glue, one of:
-
-* Python 2.7+
 
 * bzrlib.tests
 
@@ -180,10 +178,8 @@ cleanup, and return the fixture. This lets one write::
   >>> import testtools
   >>> import unittest
 
-Note that we use testtools TestCase here as we need to guarantee a
-TestCase.addCleanup method in this doctest. Unittest2 - Python2.7 and above -
-also have ``addCleanup``. testtools has it's own implementation of
-``useFixture`` so there is no need to use ``fixtures.TestWithFixtures`` with
+Note that we use ``testtools.TestCase``. testtools has it's own implementation
+of ``useFixture`` so there is no need to use ``fixtures.TestWithFixtures`` with
 ``testtools.TestCase``.
 
   >>> class NoddyTest(testtools.TestCase, fixtures.TestWithFixtures):
@@ -396,7 +392,7 @@ Adapts ``mock.patch.multiple`` to be used as a Fixture.
 MonkeyPatch
 +++++++++++
 
-Control the value of a named python attribute.
+Control the value of a named Python attribute.
 
   >>> def fake_open(path, mode):
   ...     pass
@@ -418,7 +414,7 @@ temporary file creation where an explicit containing directory was provided.
 PackagePathEntry
 ++++++++++++++++
 
-Adds a single directory to the path for an existing python package. This adds
+Adds a single directory to the path for an existing Python package. This adds
 to the package.__path__ list. If the directory is already in the path, nothing
 happens, if it isn't then it is added on setUp and removed on cleanUp.
 
@@ -498,6 +494,5 @@ system call.
 Contributing
 ============
 
-Fixtures has its project homepage on Launchpad
-<https://launchpad.net/python-fixtures>. Source code is hosted on GitHub
+Fixtures has its project homepage on GitHub
 <https://github.com/testing-cabal/fixtures>.

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, 2011, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -29,7 +29,7 @@ Most users will want to look at TestWithFixtures and Fixture, to start with.
 # the version number: major, minor, micro, releaselevel, and serial. All
 # values except releaselevel are integers; the release level is 'alpha',
 # 'beta', 'candidate', or 'final'. The version_info value corresponding to the
-# Python version 2.0 is (2, 0, 0, 'final', 0)."  Additionally we use a
+# Python version 3.9 is (3, 9, 0, 'final', 0)."  Additionally we use a
 # releaselevel of 'dev' for unreleased under-development code.
 #
 # If the releaselevel is 'alpha' then the major/minor/micro components are not

--- a/fixtures/_fixtures/logger.py
+++ b/fixtures/_fixtures/logger.py
@@ -16,9 +16,6 @@
 from logging import StreamHandler, getLogger, INFO, Formatter
 import sys
 
-import six
-from testtools.compat import _u
-
 from fixtures import Fixture
 from fixtures._fixtures.streams import StringStream
 
@@ -66,7 +63,8 @@ class LogHandler(Fixture):
 class StreamHandlerRaiseException(StreamHandler):
     """Handler class that will raise an exception on formatting errors."""
     def handleError(self, record):
-        six.reraise(*sys.exc_info())
+        _, value, tb = sys.exc_info()
+        raise value.with_traceback(tb)
 
 
 class FakeLogger(Fixture):
@@ -103,7 +101,7 @@ class FakeLogger(Fixture):
         self._formatter = formatter
 
     def _setUp(self):
-        name = _u("pythonlogging:'%s'") % self._name
+        name = "pythonlogging:'%s'" % self._name
         output = self.useFixture(StringStream(name)).stream
         self._output = output
         handler = StreamHandlerRaiseException(output)

--- a/fixtures/_fixtures/mockpatch.py
+++ b/fixtures/_fixtures/mockpatch.py
@@ -15,13 +15,15 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-import extras
-
 import fixtures
 
-mock = extras.try_imports(['mock', 'unittest.mock'], None)
-mock_default = extras.try_imports(
-    ['mock.DEFAULT', 'unittest.mock.DEFAULT'], None)
+# TODO(stephenfin): Make this configurable
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+mock_default = mock.DEFAULT
 
 
 class _Base(fixtures.Fixture):

--- a/fixtures/_fixtures/monkeypatch.py
+++ b/fixtures/_fixtures/monkeypatch.py
@@ -83,9 +83,11 @@ def _coerce_values(obj, name, new_value, sentinel):
             # bound state rather than having it bound to the new object
             # it has been patched onto.
             captured_method = new_value
+
             @functools.wraps(old_value)
             def avoid_get(*args, **kwargs):
                 return captured_method(*args, **kwargs)
+
             new_value = avoid_get
 
     return (new_value, old_value)
@@ -138,18 +140,21 @@ class MonkeyPatch(Fixture):
             __import__(location, {}, {})
         except ImportError:
             pass
+
         components = location.split('.')
         current = __import__(components[0], {}, {})
         for component in components[1:]:
             current = getattr(current, component)
         sentinel = object()
-        new_value, old_value = _coerce_values(current, attribute,
-                self.new_value, sentinel)
+        new_value, old_value = _coerce_values(
+            current, attribute, self.new_value, sentinel)
+
         if self.new_value is self.delete:
             if old_value is not sentinel:
                 delattr(current, attribute)
         else:
             setattr(current, attribute, new_value)
+
         if old_value is sentinel:
             self.addCleanup(self._safe_delete, current, attribute)
         else:

--- a/fixtures/_fixtures/monkeypatch.py
+++ b/fixtures/_fixtures/monkeypatch.py
@@ -15,7 +15,7 @@
 
 __all__ = [
     'MonkeyPatch'
-    ]
+]
 
 import functools
 import types
@@ -24,9 +24,6 @@ from fixtures import Fixture
 
 
 _class_types = (type, )
-if getattr(types, 'ClassType', None):
-    # Python 2 has multiple types of classes.
-    _class_types = _class_types + (types.ClassType,)
 
 
 def _coerce_values(obj, name, new_value, sentinel):

--- a/fixtures/_fixtures/streams.py
+++ b/fixtures/_fixtures/streams.py
@@ -20,7 +20,6 @@ __all__ = [
     ]
 
 import io
-import sys
 
 from fixtures import Fixture
 import testtools
@@ -69,15 +68,6 @@ def _string_stream_factory():
     upper = io.TextIOWrapper(lower, encoding="utf8")
     # See http://bugs.python.org/issue7955
     upper._CHUNK_SIZE = 1
-    # In theory, this is sufficient and correct, but on Python2,
-    # upper.write(_b('foo")) will whinge louadly.
-    if sys.version_info[0] < 3:
-        upper_write = upper.write
-        def safe_write(str_or_bytes):
-            if type(str_or_bytes) is str:
-                str_or_bytes = str_or_bytes.decode('utf8')
-            return upper_write(str_or_bytes)
-        upper.write = safe_write
     return upper, lower
 
 

--- a/fixtures/callmany.py
+++ b/fixtures/callmany.py
@@ -19,9 +19,6 @@ __all__ = [
 
 import sys
 
-from testtools.compat import (
-    reraise,
-    )
 from testtools.helpers import try_import
 
 
@@ -86,7 +83,7 @@ class CallMany(object):
         if result and raise_errors:
             if 1 == len(result):
                 error = result[0]
-                reraise(error[0], error[1], error[2])
+                raise error[1].with_traceback(error[2])
             else:
                 raise MultipleExceptions(*result)
         if not raise_errors:

--- a/fixtures/fixture.py
+++ b/fixtures/fixture.py
@@ -25,10 +25,6 @@ __all__ = [
 import itertools
 import sys
 
-import six
-from testtools.compat import (
-    advance_iterator,
-    )
 from testtools.helpers import try_import
 
 from fixtures.callmany import (
@@ -46,7 +42,7 @@ def combine_details(source_details, target_details):
         new_name = name
         disambiguator = itertools.count(1)
         while new_name in target_details:
-            new_name = '%s-%d' % (name, advance_iterator(disambiguator))
+            new_name = '%s-%d' % (name, next(disambiguator))
         name = new_name
         target_details[name] = content_object
 
@@ -211,7 +207,7 @@ class Fixture(object):
             if issubclass(err[0], Exception):
                 raise MultipleExceptions(*errors)
             else:
-                six.reraise(*err)
+                raise err[1].with_traceback(err[2])
 
     def _setUp(self):
         """Template method for subclasses to override.

--- a/fixtures/tests/_fixtures/test_logger.py
+++ b/fixtures/tests/_fixtures/test_logger.py
@@ -13,13 +13,12 @@
 # license you chose for the specific language governing permissions and
 # limitations under that license.
 
+import io
 import logging
-import sys
 import time
 
 import testtools
 from testtools import TestCase
-from testtools.compat import StringIO
 
 from fixtures import (
     FakeLogger,
@@ -32,12 +31,8 @@ from fixtures import (
 # testing formatter overrides.
 class FooFormatter(logging.Formatter):
     def format(self, record):
-        # custom formatters interface changes in python 3.2
-        if sys.version_info < (3, 2):
-            self._fmt = "Foo " + self._fmt
-        else:
-            self._style = logging.PercentStyle("Foo " + self._style._fmt)
-            self._fmt = self._style._fmt
+        self._style = logging.PercentStyle("Foo " + self._style._fmt)
+        self._fmt = self._style._fmt
         return logging.Formatter.format(self, record)
 
 
@@ -58,7 +53,7 @@ class FakeLoggerTest(TestCase, TestWithFixtures):
         self.assertEqual("some message\n", fixture.output)
 
     def test_replace_and_restore_handlers(self):
-        stream = StringIO()
+        stream = io.StringIO()
         logger = logging.getLogger()
         logger.addHandler(logging.StreamHandler(stream))
         logger.setLevel(logging.INFO)
@@ -71,7 +66,7 @@ class FakeLoggerTest(TestCase, TestWithFixtures):
         self.assertEqual("one\nthree\n", stream.getvalue())
 
     def test_preserving_existing_handlers(self):
-        stream = StringIO()
+        stream = io.StringIO()
         self.logger.addHandler(logging.StreamHandler(stream))
         self.logger.setLevel(logging.INFO)
         fixture = FakeLogger(nuke_handlers=False)
@@ -174,7 +169,7 @@ class LogHandlerTest(TestCase, TestWithFixtures):
         self.assertEqual(["some message"], fixture.handler.msgs)
 
     def test_replace_and_restore_handlers(self):
-        stream = StringIO()
+        stream = io.StringIO()
         logger = logging.getLogger()
         logger.addHandler(logging.StreamHandler(stream))
         logger.setLevel(logging.INFO)
@@ -187,7 +182,7 @@ class LogHandlerTest(TestCase, TestWithFixtures):
         self.assertEqual("one\nthree\n", stream.getvalue())
 
     def test_preserving_existing_handlers(self):
-        stream = StringIO()
+        stream = io.StringIO()
         self.logger.addHandler(logging.StreamHandler(stream))
         self.logger.setLevel(logging.INFO)
         fixture = LogHandler(self.CustomHandler(), nuke_handlers=False)

--- a/fixtures/tests/_fixtures/test_popen.py
+++ b/fixtures/tests/_fixtures/test_popen.py
@@ -13,13 +13,10 @@
 # license you chose for the specific language governing permissions and
 # limitations under that license.
 
+import io
 import subprocess
 
 import testtools
-from testtools.compat import (
-    _b,
-    BytesIO,
-    )
 
 from fixtures import FakePopen, TestWithFixtures
 from fixtures._fixtures.popen import FakeProcess
@@ -92,23 +89,23 @@ class TestFakeProcess(testtools.TestCase):
         self.assertEqual(0, proc.returncode)
 
     def test_communicate_with_out(self):
-        proc = FakeProcess({}, {'stdout': BytesIO(_b('foo'))})
-        self.assertEqual((_b('foo'), ''), proc.communicate())
+        proc = FakeProcess({}, {'stdout': io.BytesIO(b'foo')})
+        self.assertEqual((b'foo', ''), proc.communicate())
         self.assertEqual(0, proc.returncode)
 
     def test_communicate_with_input(self):
-        proc = FakeProcess({}, {'stdout': BytesIO(_b('foo'))})
-        self.assertEqual((_b('foo'), ''), proc.communicate(input=_b("bar")))
+        proc = FakeProcess({}, {'stdout': io.BytesIO(b'foo')})
+        self.assertEqual((b'foo', ''), proc.communicate(input=b'bar'))
 
     def test_communicate_with_input_and_stdin(self):
-        stdin = BytesIO()
+        stdin = io.BytesIO()
         proc = FakeProcess({}, {'stdin': stdin})
-        proc.communicate(input=_b("hello"))
-        self.assertEqual(_b("hello"), stdin.getvalue())
+        proc.communicate(input=b'hello')
+        self.assertEqual(b'hello', stdin.getvalue())
 
     def test_communicate_with_timeout(self):
-        proc = FakeProcess({}, {'stdout': BytesIO(_b('foo'))})
-        self.assertEqual((_b('foo'), ''), proc.communicate(timeout=10))
+        proc = FakeProcess({}, {'stdout': io.BytesIO(b'foo')})
+        self.assertEqual((b'foo', ''), proc.communicate(timeout=10))
 
     def test_args(self):
         proc = FakeProcess({"args": ["ls", "-lh"]}, {})
@@ -133,4 +130,4 @@ class TestFakeProcess(testtools.TestCase):
 
     def test_wait_with_timeout_and_endtime(self):
         proc = FakeProcess({}, {})
-        self.assertEqual(0 , proc.wait(timeout=4, endtime=7))
+        self.assertEqual(0, proc.wait(timeout=4, endtime=7))

--- a/fixtures/tests/_fixtures/test_pythonpackage.py
+++ b/fixtures/tests/_fixtures/test_pythonpackage.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -16,7 +16,6 @@
 import os.path
 
 import testtools
-from testtools.compat import _b
 
 from fixtures import PythonPackage, TestWithFixtures
 
@@ -32,7 +31,7 @@ class TestPythonPackage(testtools.TestCase, TestWithFixtures):
             fixture.cleanUp()
    
     def test_writes_package(self):
-        fixture = PythonPackage('foo', [('bar.py', _b('woo'))])
+        fixture = PythonPackage('foo', [('bar.py', b'woo')])
         fixture.setUp()
         try:
             self.assertEqual('', open(os.path.join(fixture.base, 'foo',
@@ -43,7 +42,7 @@ class TestPythonPackage(testtools.TestCase, TestWithFixtures):
             fixture.cleanUp()
 
     def test_no__init__(self):
-        fixture = PythonPackage('foo', [('bar.py', _b('woo'))], init=False)
+        fixture = PythonPackage('foo', [('bar.py', b'woo')], init=False)
         fixture.setUp()
         try:
             self.assertFalse(os.path.exists(os.path.join(fixture.base, 'foo',

--- a/fixtures/tests/_fixtures/test_streams.py
+++ b/fixtures/tests/_fixtures/test_streams.py
@@ -14,10 +14,6 @@
 # limitations under that license.
 
 from testtools import TestCase
-from testtools.compat import (
-    _b,
-    _u,
-    )
 from testtools.matchers import Contains
 
 from fixtures import (
@@ -40,7 +36,7 @@ class TestByteStreams(TestCase):
         fixture = ByteStream(detail_name)
         with fixture:
             content = fixture.getDetails()[detail_name]
-            self.assertEqual(_u(""), content.as_text())
+            self.assertEqual("", content.as_text())
 
     def test_stream_content_in_details(self):
         detail_name = 'test'
@@ -49,7 +45,7 @@ class TestByteStreams(TestCase):
             stream = fixture.stream
             content = fixture.getDetails()[detail_name]
             # Output after getDetails is called is included.
-            stream.write(_b("testing 1 2 3"))
+            stream.write(b"testing 1 2 3")
             self.assertEqual("testing 1 2 3", content.as_text())
 
     def test_stream_content_reset(self):
@@ -58,15 +54,15 @@ class TestByteStreams(TestCase):
         with fixture:
             stream = fixture.stream
             content = fixture.getDetails()[detail_name]
-            stream.write(_b("testing 1 2 3"))
+            stream.write(b"testing 1 2 3")
         with fixture:
             # The old content object returns the old usage
-            self.assertEqual(_u("testing 1 2 3"), content.as_text())
+            self.assertEqual("testing 1 2 3", content.as_text())
             content = fixture.getDetails()[detail_name]
             # A new fixture returns the new output:
             stream = fixture.stream
-            stream.write(_b("1 2 3 testing"))
-            self.assertEqual(_u("1 2 3 testing"), content.as_text())
+            stream.write(b"1 2 3 testing")
+            self.assertEqual("1 2 3 testing", content.as_text())
 
 
 class TestStringStreams(TestCase):
@@ -76,7 +72,7 @@ class TestStringStreams(TestCase):
         fixture = StringStream(detail_name)
         with fixture:
             content = fixture.getDetails()[detail_name]
-            self.assertEqual(_u(""), content.as_text())
+            self.assertEqual("", content.as_text())
 
     def test_stream_content_in_details(self):
         detail_name = 'test'
@@ -85,7 +81,7 @@ class TestStringStreams(TestCase):
             stream = fixture.stream
             content = fixture.getDetails()[detail_name]
             # Output after getDetails is called is included.
-            stream.write(_u("testing 1 2 3"))
+            stream.write("testing 1 2 3")
             self.assertEqual("testing 1 2 3", content.as_text())
 
     def test_stream_content_reset(self):
@@ -94,12 +90,12 @@ class TestStringStreams(TestCase):
         with fixture:
             stream = fixture.stream
             content = fixture.getDetails()[detail_name]
-            stream.write(_u("testing 1 2 3"))
+            stream.write("testing 1 2 3")
         with fixture:
             # The old content object returns the old usage
-            self.assertEqual(_u("testing 1 2 3"), content.as_text())
+            self.assertEqual("testing 1 2 3", content.as_text())
             content = fixture.getDetails()[detail_name]
             # A new fixture returns the new output:
             stream = fixture.stream
-            stream.write(_u("1 2 3 testing"))
-            self.assertEqual(_u("1 2 3 testing"), content.as_text())
+            stream.write("1 2 3 testing")
+            self.assertEqual("1 2 3 testing", content.as_text())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 pbr>=0.11
-six
 testtools>=0.9.22

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,8 @@ description-file =
     README
 author = Robert Collins
 author-email = robertc@robertcollins.net
-home-page = https://launchpad.net/python-fixtures
+home-page = https://github.com/testing-cabal/fixtures
+python-requires = >=3.6
 classifier =
     Development Status :: 6 - Mature
     Intended Audience :: Developers
@@ -13,12 +14,11 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Quality Assurance
@@ -28,11 +28,8 @@ classifier =
 packages =
     fixtures
 
-[bdist_wheel]
-universal = 1
-
 [extras]
 test =
-  mock
+    mock
 docs =
-  docutils
+    docutils

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py27,py34,py35,py36,pypy,pypy3
-minversion = 1.6
-skipsdist = True
+envlist = py36,py37,py38,py39,pypy3
+minversion = 3.1
+skipsdist = true
 
 [testenv]
-usedevelop = True
-install_command = pip install -U {opts} {packages}
-setenv = VIRTUAL_ENV={envdir}
+usedevelop = true
 whitelist_externals = make
 deps = .[docs,test]
 commands = make check


### PR DESCRIPTION
This requires a rather tricky test fix due to changes in behavior of
the 'classmethod' decorator in Python 3.9. We also take the opportunity
to remove some unnecessary libraries ('extras' and 'six') and generally
tidy things up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/46)
<!-- Reviewable:end -->
