### PR TITLE
Make mock library used configurable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,7 +6,15 @@ NEXT
 ~~~~
 
 * Dropped support for Python 2.7, Python 3.4 and Python 3.5 (EOL)
+
 * Added support for Python 3.7, Python 3.8, and Python 3.9
+
+* The mock library used by the ``MockPatchObject``, ``MockPatch``, and
+  ``MockPatchMultiple`` fixtures is now configurable using the
+  ``FIXTURES_MOCK_LIBRARY`` environment variable. Three values are accepted:
+  ``unittest`` (use ``unittest.mock``), ``mock`` (use the ``mock`` library),
+  and ``any`` (prefer ``mock``, but fallback to ``unittest.mock`` if not
+  present)
 
 3.0.0
 ~~~~~

--- a/fixtures/_fixtures/mockpatch.py
+++ b/fixtures/_fixtures/mockpatch.py
@@ -15,13 +15,24 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import os
+
 import fixtures
 
-# TODO(stephenfin): Make this configurable
-try:
+FIXTURES_MOCK_LIBRARY = os.getenv('FIXTURES_MOCK_LIBRARY', 'any').lower()
+if FIXTURES_MOCK_LIBRARY not in ('any', 'mock', 'unittest'):  # ignore invalid
+    FIXTURES_MOCK_LIBRARY = 'any'
+
+
+if FIXTURES_MOCK_LIBRARY == 'mock':
     import mock
-except ImportError:
+elif FIXTURES_MOCK_LIBRARY == 'unittest':
     import unittest.mock as mock
+else:
+    try:
+        import mock
+    except ImportError:
+        import unittest.mock as mock
 
 mock_default = mock.DEFAULT
 


### PR DESCRIPTION
`mock.Mock` != `unittest.mock.Mock`. This can make some tests in consuming projects more complicated that necessary while they switch from one to the other.

This is intended to make life easier in OpenStack nova, as we pivot from `mock` to `unittest.mock`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/49)
<!-- Reviewable:end -->
