### PR TITLE
Add WarningsFilter fixture

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ NEXT
 * Drop support for Python 3.6 (EOL)
   (Stephen Finucane)
 
+* Add a new ``WarningsFilter`` filter, allowing users to filter warnings as
+  part of their tests, before restoring said filters.
+  (Stephen Finucane)
+
 4.0.1
 ~~~~~
 

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -73,6 +73,7 @@ __all__ = [
     'Timeout',
     'TimeoutException',
     'WarningsCapture',
+    'WarningsFilter',
     '__version__',
     'version',
     ]
@@ -110,6 +111,7 @@ from fixtures._fixtures import (
     Timeout,
     TimeoutException,
     WarningsCapture,
+    WarningsFilter,
     )
 from fixtures.testcase import TestWithFixtures
 

--- a/fixtures/_fixtures/__init__.py
+++ b/fixtures/_fixtures/__init__.py
@@ -40,7 +40,8 @@ __all__ = [
     'Timeout',
     'TimeoutException',
     'WarningsCapture',
-    ]
+    'WarningsFilter',
+]
 
 
 from fixtures._fixtures.environ import (
@@ -83,4 +84,5 @@ from fixtures._fixtures.timeout import (
     )
 from fixtures._fixtures.warnings import (
     WarningsCapture,
+    WarningsFilter,
     )

--- a/fixtures/_fixtures/warnings.py
+++ b/fixtures/_fixtures/warnings.py
@@ -11,10 +11,9 @@
 # license you chose for the specific language governing permissions and
 # limitations under that license.
 
-from __future__ import absolute_import
-
 __all__ = [
     'WarningsCapture',
+    'WarningsFilter',
 ]
 
 import warnings
@@ -38,3 +37,51 @@ class WarningsCapture(fixtures.Fixture):
         patch = fixtures.MonkeyPatch("warnings.showwarning", self._showwarning)
         self.useFixture(patch)
         self.captures = []
+
+
+class WarningsFilter(fixtures.Fixture):
+    """Configure warnings filters.
+
+    While ``WarningsFilter`` is active, warnings will be filtered per
+    configuration.
+    """
+
+    def __init__(self, filters=None):
+        """Create a WarningsFilter fixture.
+
+        :param filters: An optional list of dictionaries with arguments
+            corresponding to the arguments to
+            :py:func:`warnings.filterwarnings`. For example::
+
+                [
+                    {
+                        'action': 'ignore',
+                        'message': 'foo',
+                        'category': DeprecationWarning,
+                    },
+                ]
+
+            Order is important: entries closer to the front of the list
+            override entries later in the list, if both match a particular
+            warning.
+
+            Alternatively, you can configure warnings within the context of the
+            fixture.
+
+            See `the Python documentation`__ for more information.
+
+        __: https://docs.python.org/3/library/warnings.html#the-warnings-filter
+        """
+        super().__init__()
+        self.filters = filters or []
+
+    def _setUp(self):
+        self._original_warning_filters = warnings.filters[:]
+
+        for filt in self.filters:
+            warnings.filterwarnings(**filt)
+
+        self.addCleanup(self._reset_warning_filters)
+
+    def _reset_warning_filters(self):
+        warnings.filters[:] = self._original_warning_filters

--- a/fixtures/testcase.py
+++ b/fixtures/testcase.py
@@ -24,7 +24,7 @@ from fixtures.fixture import gather_details
 
 class TestWithFixtures(unittest.TestCase):
     """A TestCase with a helper function to use fixtures.
-    
+
     Normally used as a mix-in class to add useFixture.
 
     Note that test classes such as testtools.TestCase which already have a

--- a/fixtures/tests/_fixtures/__init__.py
+++ b/fixtures/tests/_fixtures/__init__.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -27,7 +27,8 @@ def load_tests(loader, standard_tests, pattern):
         'tempdir',
         'temphomedir',
         'timeout',
-        ]
+        'warnings',
+    ]
     prefix = "fixtures.tests._fixtures.test_"
     test_mod_names = [prefix + test_module for test_module in test_modules]
     standard_tests.addTests(loader.loadTestsFromNames(test_mod_names))

--- a/fixtures/tests/_fixtures/test_warnings.py
+++ b/fixtures/tests/_fixtures/test_warnings.py
@@ -21,6 +21,10 @@ import fixtures
 class TestWarnings(testtools.TestCase, fixtures.TestWithFixtures):
 
     def test_capture_reuse(self):
+        # DeprecationWarnings are hidden by default in Python 3.2+, enable them
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+        warnings.simplefilter("always")
+
         w = fixtures.WarningsCapture()
         with w:
             warnings.warn("test", DeprecationWarning)
@@ -29,12 +33,20 @@ class TestWarnings(testtools.TestCase, fixtures.TestWithFixtures):
             self.assertEqual([], w.captures)
 
     def test_capture_message(self):
+        # DeprecationWarnings are hidden by default in Python 3.2+, enable them
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+        warnings.simplefilter("always")
+
         w = self.useFixture(fixtures.WarningsCapture())
         warnings.warn("hi", DeprecationWarning)
         self.assertEqual(1, len(w.captures))
         self.assertEqual("hi", str(w.captures[0].message))
 
     def test_capture_category(self):
+        # DeprecationWarnings are hidden by default in Python 3.2+, enable them
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+        warnings.simplefilter("always")
+
         w = self.useFixture(fixtures.WarningsCapture())
         categories = [
             DeprecationWarning, Warning, UserWarning,

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ usedevelop = true
 extras =
   docs
   test
-commands = python -m testtools.run fixtures.test_suite
+commands = python -m testtools.run fixtures.test_suite {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ usedevelop = true
 extras =
   docs
   test
-commands = python -m testtools.run fixtures.test_suite {posargs}
+commands = python -m testtools.run fixtures.test_suite


### PR DESCRIPTION
This has enough users around OpenStack to justify adding it to 'fixtures' proper. It's intentionally dumb, since the main purpose of this is to avoid people calling `resetwarnings` in their variant of the fixture, as that clears *all* filters including those we don't control.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/50)
<!-- Reviewable:end -->
