### PR TITLE
Fix MockPatchMultiple.DEFAULT

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v2
         with:

--- a/fixtures/_fixtures/mockpatch.py
+++ b/fixtures/_fixtures/mockpatch.py
@@ -51,14 +51,24 @@ class MockPatch(_Base):
         self._get_p = lambda: mock.patch(obj, new, **kwargs)
 
 
-class MockPatchMultiple(_Base):
-    """Deal with code around mock.patch.multiple."""
+class _MockPatchMultipleMeta(type):
+    """Arrange for lazy loading of MockPatchMultiple.DEFAULT."""
+
+    # For strict backward compatibility, ensure that DEFAULT also works as
+    # an instance property.
+    def __new__(cls, name, bases, namespace, **kwargs):
+        namespace['DEFAULT'] = cls.DEFAULT
+        return super().__new__(cls, name, bases, namespace, **kwargs)
 
     # Default value to trigger a MagicMock to be created for a named
     # attribute.
     @property
     def DEFAULT(self):
         return mock.DEFAULT
+
+
+class MockPatchMultiple(_Base, metaclass=_MockPatchMultipleMeta):
+    """Deal with code around mock.patch.multiple."""
 
     def __init__(self, obj, **kwargs):
         """Initialize the mocks


### PR DESCRIPTION
The change in #52 broke
`TestMockMultiple.test_mock_patch_without_replacement`, since
`MockPatchMultiple.DEFAULT` no longer worked as a class property.  Fix
this using a metaclass.

For compatibility, I arranged for it to also work as an instance
property; I suspect this isn't much needed since
`MockPatchMultiple.DEFAULT` is normally used as an argument to the
`MockPatchMultiple` constructor so you wouldn't normally have an
instance in hand, but it's easy enough to provide strict compatibility
here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/55)
<!-- Reviewable:end -->
