### PR TITLE
Move testtools requirement to a "streams" extra

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ NEXT
 * Dropped support for Python 2.7, Python 3.4 and Python 3.5 (EOL).
 * Added support for Python 3.7-3.10.
 * Support all ``subprocess.Popen`` arguments up to Python 3.10.
+* Move ``testtools`` requirement to a new ``fixtures[streams]`` extra.
 
 3.0.0
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -336,6 +336,8 @@ in test failure descriptions. Very useful in combination with MonkeyPatch.
   ...     pass
   >>> fixture.cleanUp()
 
+This requires the ``fixtures[streams]`` extra.
+
 EnvironmentVariable
 +++++++++++++++++++
 
@@ -449,6 +451,8 @@ in test failure descriptions. Very useful in combination with MonkeyPatch.
   >>> with fixtures.MonkeyPatch('sys.stdout', fixture.stream):
   ...     pass
   >>> fixture.cleanUp()
+
+This requires the ``fixtures[streams]`` extra.
 
 TempDir
 +++++++

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,8 @@ Dependencies
 * pbr
   Used for version and release management of fixtures.
 
+The ``fixtures[streams]`` extra adds:
+
 * testtools <https://launchpad.net/testtools> 0.9.22 or newer.
   testtools provides helpful glue functions for the details API used to report
   information about a fixture (whether its used in a testing or production

--- a/fixtures/_fixtures/streams.py
+++ b/fixtures/_fixtures/streams.py
@@ -22,7 +22,6 @@ __all__ = [
 import io
 
 from fixtures import Fixture
-import testtools
 
 
 class Stream(Fixture):
@@ -42,10 +41,14 @@ class Stream(Fixture):
         self._stream_factory = stream_factory
 
     def _setUp(self):
+        # Available with the fixtures[streams] extra.
+        from testtools.content import content_from_stream
+
         write_stream, read_stream = self._stream_factory()
         self.stream = write_stream
-        self.addDetail(self._detail_name,
-            testtools.content.content_from_stream(read_stream, seek_offset=0))
+        self.addDetail(
+            self._detail_name,
+            content_from_stream(read_stream, seek_offset=0))
 
 
 def _byte_stream_factory():

--- a/fixtures/callmany.py
+++ b/fixtures/callmany.py
@@ -19,14 +19,12 @@ __all__ = [
 
 import sys
 
-from testtools.helpers import try_import
 
-
-class MultipleExceptions(Exception):
-    """Report multiple exc_info tuples in self.args."""
-
-MultipleExceptions = try_import(
-    "testtools.MultipleExceptions", MultipleExceptions)
+try:
+    from testtools import MultipleExceptions
+except ImportError:
+    class MultipleExceptions(Exception):
+        """Report multiple exc_info tuples in self.args."""
 
 
 class CallMany(object):

--- a/fixtures/fixture.py
+++ b/fixtures/fixture.py
@@ -25,15 +25,18 @@ __all__ = [
 import itertools
 import sys
 
-from testtools.helpers import try_import
-
 from fixtures.callmany import (
     CallMany,
     # Deprecated, imported for compatibility.
     MultipleExceptions,
     )
 
-gather_details = try_import("testtools.testcase.gather_details")
+
+try:
+    from testtools.testcase import gather_details
+except ImportError:
+    gather_details = None
+
 
 # This would be better in testtools (or a common library)
 def combine_details(source_details, target_details):

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,10 @@ packages =
     fixtures
 
 [extras]
+streams =
+    testtools
 test =
     mock
+    testtools
 docs =
     docutils


### PR DESCRIPTION
Stop using `testtools.helpers.try_import`, as it's only barely more complex to just write out the `try`/`except` directly.

After that, all that remains to make `testtools` optional and break the cyclic requirement is to deal with its use by streams fixtures.  These intrinsically rely on `testtools`, but are also very much optional, so move the requirement to a new `fixtures[streams]` extra.

Fixes #38.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/62)
<!-- Reviewable:end -->
