### PR TITLE
Release 4.0.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ fixtures release notes
 NEXT
 ~~~~
 
+4.0.0
+~~~~~
+
 * Add missing APIs to ``FakeProcess``, making it match ``Popen``.
   (Free Ekanayaka, #1373224)
 

--- a/NEWS
+++ b/NEWS
@@ -5,10 +5,25 @@ fixtures release notes
 NEXT
 ~~~~
 
+* Add missing APIs to ``FakeProcess``, making it match ``Popen``.
+  (Free Ekanayaka, #1373224)
+
 * Dropped support for Python 2.7, Python 3.4 and Python 3.5 (EOL).
-* Added support for Python 3.7-3.10.
+  (Hugo van Kemenade)
+
+* Added support for Python 3.6-3.10.
+  (Free Ekanayaka, Stephen Finucane, Colin Watson)
+
+* Add possibility to reset the ``FakeLogger``. (Balazs Gibizer)
+
+* Access ``mock.DEFAULT`` lazily rather than at import time so ``mock`` can
+  be overridden with something else. (Jelmer Vernooĳ)
+
 * Support all ``subprocess.Popen`` arguments up to Python 3.10.
+  (Jürgen Gmach, Colin Watson)
+
 * Move ``testtools`` requirement to a new ``fixtures[streams]`` extra.
+  (Colin Watson)
 
 3.0.0
 ~~~~~


### PR DESCRIPTION
Given the use of `python_requires`, it probably isn't strictly necessary to bump the major version for dropping Python version support, but it seems prudent to do so in light of moving the `testtools` requirement to an extra.  (In practice I suspect anyone who needs this fixture was already explicitly requiring `testtools` anyway, but you never know.)

If people are OK with this, then I'll tag it and push to PyPI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/63)
<!-- Reviewable:end -->
