### PR TITLE
Revert to the previous classmethod expectations for PyPy3.9

### DIFF
--- a/fixtures/tests/_fixtures/test_monkeypatch.py
+++ b/fixtures/tests/_fixtures/test_monkeypatch.py
@@ -23,6 +23,9 @@ from fixtures import MonkeyPatch, TestWithFixtures
 
 reference = 23
 
+NEW_PY39_CLASSMETHOD = (
+    sys.version_info >= (3, 9) and not hasattr(sys, "pypy_version_info"))
+
 class C(object):
     def foo(self, arg):
         return arg
@@ -196,7 +199,7 @@ class TestMonkeyPatch(testtools.TestCase, TestWithFixtures):
             # with the class
             #
             # https://bugs.python.org/issue19072
-            if sys.version_info >= (3, 9):
+            if NEW_PY39_CLASSMETHOD:
                 cls, = C.foo_cls()
                 self.expectThat(cls, Is(D))
                 cls, = C().foo_cls()
@@ -238,13 +241,13 @@ class TestMonkeyPatch(testtools.TestCase, TestWithFixtures):
             self.expectThat(slf, Is(d))
             # See note in test_patch_classmethod_with_classmethod on changes in
             # Python 3.9
-            if sys.version_info >= (3, 9):
+            if NEW_PY39_CLASSMETHOD:
                 self.expectThat(cls, Is(None))
             else:
                 self.expectThat(cls, Is(C))
             slf, cls = C().foo_cls()
             self.expectThat(slf, Is(d))
-            if sys.version_info >= (3, 9):
+            if NEW_PY39_CLASSMETHOD:
                 self.expectThat(cls, Is(None))
             else:
                 self.expectThat(cls, Is(C))


### PR DESCRIPTION
Commit fe83067 has changed TestMonkeyPatch to account for changes
in classmethod handling in CPython 3.9.  Unfortunately, this broke
the tests on PyPy3.9.  Revert to the old expectations when using PyPy.

Fixes #64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/65)
<!-- Reviewable:end -->
