### PR TITLE
Update classmethod expectations (again) for Python 3.11

### DIFF
--- a/fixtures/tests/_fixtures/test_monkeypatch.py
+++ b/fixtures/tests/_fixtures/test_monkeypatch.py
@@ -24,7 +24,8 @@ from fixtures import MonkeyPatch, TestWithFixtures
 reference = 23
 
 NEW_PY39_CLASSMETHOD = (
-    sys.version_info >= (3, 9) and not hasattr(sys, "pypy_version_info"))
+    sys.version_info[:2] in ((3, 9), (3,10))
+    and not hasattr(sys, "pypy_version_info"))
 
 class C(object):
     def foo(self, arg):


### PR DESCRIPTION
It seems that the classmethod behavior in Python 3.11.0b1 is back
to the one found in Python 3.8.  Adjust the test expectations again.
This time around, we expect the "old-new" behavior in CPython 3.9
and 3.10 only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/67)
<!-- Reviewable:end -->
