### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta - 3.11", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11.0-beta - 3.11", "pypy-3.7", "pypy-3.8", "pypy-3.9"]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ fixtures release notes
 NEXT
 ~~~~
 
+* Drop support for Python 3.6 (EOL)
+  (Stephen Finucane)
+
 4.0.1
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ compatible test cases easy and straight forward.
 Dependencies
 ============
 
-* Python 3.6+
+* Python 3.7+
   This is the base language fixtures is written in and for.
 
 * pbr

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ description_content_type = text/x-rst; charset=UTF-8
 author = Robert Collins
 author_email = robertc@robertcollins.net
 url = https://github.com/testing-cabal/fixtures
-python_requires = >=3.6
+python_requires = >=3.7
 classifiers =
     Development Status :: 6 - Mature
     Intended Audience :: Developers
@@ -16,7 +16,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,pypy3
+envlist = py37,py38,py39,py310,py311,pypy3
 minversion = 3.1
 
 [testenv]


### PR DESCRIPTION
It's EOL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/73)
<!-- Reviewable:end -->
