### PR TITLE
Don't explicitly build-require wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["pbr>=5.7.0", "setuptools>=36.6.0", "wheel"]
+requires = ["pbr>=5.7.0", "setuptools>=36.6.0"]
 build-backend = "pbr.build"


### PR DESCRIPTION
Don't explicitly build-require wheel

See https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/74)
<!-- Reviewable:end -->
