### PR TITLE
Replace hardcoded list of tests

### DIFF
--- a/fixtures/testcase.py
+++ b/fixtures/testcase.py
@@ -24,7 +24,7 @@ from fixtures.fixture import gather_details
 
 class TestWithFixtures(unittest.TestCase):
     """A TestCase with a helper function to use fixtures.
-    
+
     Normally used as a mix-in class to add useFixture.
 
     Note that test classes such as testtools.TestCase which already have a

--- a/fixtures/tests/_fixtures/__init__.py
+++ b/fixtures/tests/_fixtures/__init__.py
@@ -13,23 +13,16 @@
 # license you chose for the specific language governing permissions and
 # limitations under that license.
 
+import os
+
+
 def load_tests(loader, standard_tests, pattern):
     test_modules = [
-        'environ',
-        'logger',
-        'mockpatch',
-        'monkeypatch',
-        'packagepath',
-        'popen',
-        'pythonpackage',
-        'pythonpath',
-        'streams',
-        'tempdir',
-        'temphomedir',
-        'timeout',
-        'warnings',
+        os.path.splitext(path)[0]
+        for path in os.listdir(os.path.dirname(__file__))
+        if path.startswith('test_')
     ]
-    prefix = "fixtures.tests._fixtures.test_"
+    prefix = "fixtures.tests._fixtures."
     test_mod_names = [prefix + test_module for test_module in test_modules]
     standard_tests.addTests(loader.loadTestsFromNames(test_mod_names))
     return standard_tests

--- a/fixtures/tests/_fixtures/__init__.py
+++ b/fixtures/tests/_fixtures/__init__.py
@@ -1,12 +1,12 @@
 #  fixtures: Fixtures with cleanups for testing and convenience.
 #
 # Copyright (c) 2010, Robert Collins <robertc@robertcollins.net>
-# 
+#
 # Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
 # license at the users choice. A copy of both licenses are available in the
 # project source as Apache-2.0 and BSD. You may not use this file except in
 # compliance with one of these two licences.
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
@@ -27,7 +27,8 @@ def load_tests(loader, standard_tests, pattern):
         'tempdir',
         'temphomedir',
         'timeout',
-        ]
+        'warnings',
+    ]
     prefix = "fixtures.tests._fixtures.test_"
     test_mod_names = [prefix + test_module for test_module in test_modules]
     standard_tests.addTests(loader.loadTestsFromNames(test_mod_names))

--- a/fixtures/tests/_fixtures/test_warnings.py
+++ b/fixtures/tests/_fixtures/test_warnings.py
@@ -21,6 +21,10 @@ import fixtures
 class TestWarnings(testtools.TestCase, fixtures.TestWithFixtures):
 
     def test_capture_reuse(self):
+        # DeprecationWarnings are hidden by default in Python 3.2+, enable them
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+        warnings.simplefilter("always")
+
         w = fixtures.WarningsCapture()
         with w:
             warnings.warn("test", DeprecationWarning)
@@ -29,12 +33,20 @@ class TestWarnings(testtools.TestCase, fixtures.TestWithFixtures):
             self.assertEqual([], w.captures)
 
     def test_capture_message(self):
+        # DeprecationWarnings are hidden by default in Python 3.2+, enable them
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+        warnings.simplefilter("always")
+
         w = self.useFixture(fixtures.WarningsCapture())
         warnings.warn("hi", DeprecationWarning)
         self.assertEqual(1, len(w.captures))
         self.assertEqual("hi", str(w.captures[0].message))
 
     def test_capture_category(self):
+        # DeprecationWarnings are hidden by default in Python 3.2+, enable them
+        # https://docs.python.org/3/library/warnings.html#default-warning-filter
+        warnings.simplefilter("always")
+
         w = self.useFixture(fixtures.WarningsCapture())
         categories = [
             DeprecationWarning, Warning, UserWarning,

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ usedevelop = true
 extras =
   docs
   test
-commands = python -m testtools.run fixtures.test_suite
+commands = python -m testtools.run fixtures.test_suite {posargs}


### PR DESCRIPTION
In #50, I noticed that we weren't running some recently added tests since they hadn't been added to the hardcoded list of test modules found in `fixtures/tests/_fixtures/__init__.py`. Prevent this happening again by searching the test directory for matching modules instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/75)
<!-- Reviewable:end -->
