### PR TITLE
Test Python 3.12 also via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,pypy3
+envlist = py37,py38,py39,py310,py311,py312,pypy3
 minversion = 3.1
 
 [testenv]


### PR DESCRIPTION
This was missed when adding Python 3.12 support via #85

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/86)
<!-- Reviewable:end -->
