### PR TITLE
Include missing configuration, license and metadata files in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,4 +47,15 @@ source = "vcs"
 version-file = "fixtures/_version.py"
 
 [tool.hatch.build.targets.sdist]
-include = ["fixtures*"]
+include = [
+    "fixtures*",
+    "APACHE-2.0",
+    "BSD",
+    "ChangeLog",
+    "COPYING",
+    "GOALS",
+    "HACKING",
+    "Makefile",
+    "NEWS",
+    "tox.ini",
+    ]


### PR DESCRIPTION
These had been left out when the build system was switched from setuptools to hatch(ling).

This fixes #100 

I have not changed the contents of the wheel, which currently only includes the `fixtures` folder. Please let me know if I also need to update that file. Though I have looked at popular wheel files and they do not seem to include anything except the code.