### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.8", "pypy-3.9"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.9"]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -43,11 +43,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install docutils
       - name: Build docs
-        run: rst2html.py README.rst README.html
-        if: matrix.python == '3.8'
-      - name: Build docs
         run: rst2html README.rst README.html
-        if: matrix.python != '3.8'
       - name: Archive build results
         uses: actions/upload-artifact@v4.6.0
         with:

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ provided that makes using fixtures that meet the ``Fixtures`` contract in
 Dependencies
 ============
 
-* Python 3.8+
+* Python 3.9+
   This is the base language fixtures is written in and for.
 
 The ``fixtures[streams]`` extra adds:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -27,7 +26,7 @@ classifiers = [
 ]
 authors = [{name = "Robert Collins", email = "robertc@robertcollins.net"}]
 license = {text = "Apache-2.0 or BSD"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,py313,pypy3
+envlist = py39,py310,py311,py312,py313,pypy3
 minversion = 3.1
 
 [testenv]


### PR DESCRIPTION
Python 3.8 reached end-of-life in October 2024. Update minimum Python version to 3.9 across all configuration files.