### PR TITLE
Fix NEWS for recent releases

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ fixtures release notes
 NEXT
 ~~~~
 
-4.2.9
+4.3.1
 ~~~~~
 
 * Improve types for WarningsCapture.
@@ -16,6 +16,9 @@ NEXT
 
 * Return Self from __enter__ for better type inference.
   (Stephen Finucane)
+
+4.3.0
+~~~~~
 
 * Accept null level for FakeLogger.
   (Stephen Finucane)


### PR DESCRIPTION
I had already pushed tags for the 4.3.0 and 4.3.1 and was not expecting to see a new 4.2.9 tag (which in hindsight would have been a better choice of version number than 4.3.0). Update the NEWS file to reflect these releases.

@jelmer I will do a better job of communicating when I do cut a tag in the future or just leave it to you if you'd prefer that. My apologies. I suspect we'll likely also want to delete tags and possibly yank releases. If we yank the 4.3.0 and 4.3.1 releases, we will not be able to use them for new releases so I suspect it would be better to instead delete the 4.2.9 tag and yank that release on PyPI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/fixtures/121)
<!-- Reviewable:end -->
